### PR TITLE
Make .github/workflows/test-unstable-workaround.yml

### DIFF
--- a/.github/workflows/test-unstable-workaround.yml
+++ b/.github/workflows/test-unstable-workaround.yml
@@ -1,15 +1,15 @@
-name: test
+# This file is a workaround for the problem about "Re-run jobs" https://github.community/t5/GitHub-Actions/Ability-to-rerun-just-a-single-job-in-a-workflow/m-p/41629
+
+name: test-unstable-workaround
 
 on: [push, pull_request]
 
 jobs:
-  test:
+  test-unstable-workaround:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        pattern: [stable]
-        # pattern: [stable, unstable]
-        # see test-unstabl-workarounde.yml
+        pattern: [unstable]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        pattern: [stable]
+        python-version: [3.5, 3.6]
+        pattern: [stable]  # see test-unstabl-workarounde.yml
         # pattern: [stable, unstable]
-        # see test-unstabl-workarounde.yml
+        exclude:
+        - os: windows-latest
+          python-version: 3.6
+        - os: macos-latest
+          python-version: 3.6
+
+
 
     runs-on: ${{ matrix.os }}
 
@@ -19,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: ${{ matrix.python-version }}
 
     - name: Get pip cache
       id: pip-cache

--- a/tests/load_balancer.py
+++ b/tests/load_balancer.py
@@ -12,6 +12,7 @@ def main():
     unstable = [
         tests / 'service_codeforces.py',
         tests / 'service_codechef.py',
+        tests / 'service_poj.py',
     ]
 
     if args.keyword == 'unstable':


### PR DESCRIPTION
The current version of GitHub Actions doesn't allow users re-run a single
job. The current version requires re-runing the all job even if some of them already
succeeded, and this decreases the probability to pass the CI very much.