### PR TITLE
Surppress running CI on push

### DIFF
--- a/.github/workflows/test-unstable-workaround-macos.yml
+++ b/.github/workflows/test-unstable-workaround-macos.yml
@@ -2,7 +2,7 @@
 
 name: test-unstable-workaround
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test-unstable-workaround:

--- a/.github/workflows/test-unstable-workaround-ubuntu.yml
+++ b/.github/workflows/test-unstable-workaround-ubuntu.yml
@@ -2,7 +2,7 @@
 
 name: test-unstable-workaround
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test-unstable-workaround:

--- a/.github/workflows/test-unstable-workaround-windows.yml
+++ b/.github/workflows/test-unstable-workaround-windows.yml
@@ -2,7 +2,7 @@
 
 name: test-unstable-workaround
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test-unstable-workaround:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Running CI twice on `push` and on `pull_request` is unwelcome