### PR TITLE
Add a workaround for the conflict of the module name

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,6 +19,10 @@ jobs:
         pip3 install .
         pip3 install setuptools wheel
 
+    # see https://github.com/online-judge-tools/oj/issues/755<Paste>
+    - name: Workaround for the conflict of the module name
+      run: bash workaround_for_conflict.sh
+
     - name: Build package
       run: python3 setup.py bdist_wheel
 

--- a/.github/workflows/test-unstable-workaround-ubuntu.yml
+++ b/.github/workflows/test-unstable-workaround-ubuntu.yml
@@ -38,10 +38,14 @@ jobs:
         pip3 install --upgrade setuptools
         pip3 install .[dev]
 
+    # see https://github.com/online-judge-tools/oj/issues/755<Paste>
+    - name: Workaround for the conflict of the module name
+      run: bash workaround_for_conflict.sh
+
     - name: Load balancing
       id: load-balancing
       run: |
-          python -m tests.load_balancer ${{ matrix.pattern }}
+          python -m tests_workaround_for_conflict.load_balancer ${{ matrix.pattern }}
 
     - name: Run tests
       run: |

--- a/.github/workflows/test-unstable-workaround-windows.yml
+++ b/.github/workflows/test-unstable-workaround-windows.yml
@@ -38,10 +38,14 @@ jobs:
         pip3 install --upgrade setuptools
         pip3 install .[dev]
 
+    # see https://github.com/online-judge-tools/oj/issues/755<Paste>
+    - name: Workaround for the conflict of the module name
+      run: bash workaround_for_conflict.sh
+
     - name: Load balancing
       id: load-balancing
       run: |
-          python -m tests.load_balancer ${{ matrix.pattern }}
+          python -m tests_workaround_for_conflict.load_balancer ${{ matrix.pattern }}
 
     - name: Run tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,14 @@ jobs:
         pip3 install --upgrade setuptools
         pip3 install .[dev]
 
+    # see https://github.com/online-judge-tools/oj/issues/755<Paste>
+    - name: Workaround for the conflict of the module name
+      run: bash workaround_for_conflict.sh
+
     - name: Load balancing
       id: load-balancing
       run: |
-          python -m tests.load_balancer ${{ matrix.pattern }}
+          python -m tests_workaround_for_conflict.load_balancer ${{ matrix.pattern }}
 
     - name: Run tests
       run: |

--- a/workaround_for_conflict.sh
+++ b/workaround_for_conflict.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+replace='
+    s/\(import\|from\) onlinejudge\>/\1 onlinejudge_workaround_for_conflict/
+    /\('\''\|"\).*onlinejudge/ ! {
+        s/\<onlinejudge\.\(\w\+\)/onlinejudge_workaround_for_conflict.\1/g
+    }
+'
+
+for src in $(find onlinejudge -name \*.py) onlinejudge/py.typed ; do
+    dst=${src/onlinejudge/onlinejudge_workaround_for_conflict}
+    mkdir -p $(dirname $dst)
+    sed "$replace" < $src > $dst
+done
+
+for src in $(find tests -name \*.py)  ; do
+    dst=${src/tests/tests_workaround_for_conflict}
+    mkdir -p $(dirname $dst)
+    sed "$replace" < $src > $dst
+done


### PR DESCRIPTION
This makes `onlinejudge_workaround_for_conflict` module for the conflict of the module `onlinejudge` with old `online-judge-tools` packages.

See online-judge-tools/oj#755