### PR TITLE
add dependency, colorlog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'appdirs >= 1',
         'beautifulsoup4 >= 4',
         'colorama >= 0.3',
+        'colorlog >= 4.1.0',
         'lxml >= 4',
         'requests >= 2',
         'toml >= 0.10',


### PR DESCRIPTION
https://github.com/yosupo06/library-checker-problems/pull/434 に伴い、依存にcolorlogを追加

colorlogの理由は変更が少なくて楽と言うだけなので、その気になればcoloramaのみでやるのも可能だと思います