### PR TITLE
Support Codeforces EDU problems

### DIFF
--- a/onlinejudge_api/get_problem.py
+++ b/onlinejudge_api/get_problem.py
@@ -325,7 +325,7 @@ def main(problem: Problem, *, is_system: bool, is_compatibility: bool, is_full: 
                 "html": data.html.decode(),
             }
 
-    elif isinstance(problem, CodeforcesProblem) and problem.kind != 'problemset':
+    elif isinstance(problem, CodeforcesProblem) and problem.kind not in {'problemset', 'edu'}:
         try:
             data = problem.download_data(session=session)
         except Exception as e:

--- a/tests/get_problem_codeforces.py
+++ b/tests/get_problem_codeforces.py
@@ -146,3 +146,33 @@ class GetProblemCodeforcesTest(unittest.TestCase):
         }
         actual = main(['get-problem', url], debug=True)
         self.assertEqual(expected, actual)
+
+    def test_edu_2_2_1_a(self):
+        """This tests an educational problem.
+        """
+
+        url = 'https://codeforces.com/edu/course/2/lesson/2/1/practice/contest/269100/problem/A'
+        expected = {
+            "status": "ok",
+            "messages": [],
+            "result": {
+                "url": "https://codeforces.com/edu/course/2/lesson/2/1/practice/contest/269100/problem/A",
+                "tests": [{
+                    "input": "ababba\n",
+                    "output": "6 5 0 2 4 1 3\n"
+                }, {
+                    "input": "aaaa\n",
+                    "output": "4 3 2 1 0\n"
+                }, {
+                    "input": "ppppplppp\n",
+                    "output": "9 5 8 4 7 3 6 2 1 0\n"
+                }, {
+                    "input": "nn\n",
+                    "output": "2 1 0\n"
+                }],
+                "context": {}
+            },
+        }
+        actual = main(['get-problem', url], debug=True)
+        self.assertEqual(expected, actual)
+

--- a/tests/service_codeforces.py
+++ b/tests/service_codeforces.py
@@ -9,6 +9,7 @@ class CodeforcesSerivceTest(unittest.TestCase):
         self.assertIsInstance(CodeforcesService.from_url('http://codeforces.com/'), CodeforcesService)
         self.assertIsInstance(CodeforcesService.from_url('https://codeforces.com/'), CodeforcesService)
         self.assertIsInstance(CodeforcesService.from_url('https://codeforces.com/problemset/problem/700/B'), CodeforcesService)
+        self.assertIsInstance(CodeforcesService.from_url('https://codeforces.com/edu/course/2/lesson/2/1/practice/contest/269100/problem/A'), CodeforcesService)
         self.assertIsNone(CodeforcesService.from_url('https://atcoder.jp/'))
 
 
@@ -64,6 +65,8 @@ class CodeforcesProblemTest(unittest.TestCase):
         self.assertEqual(CodeforcesProblem.from_url('http://codeforces.com/contest/538/problem/H').index, 'H')
         self.assertEqual(CodeforcesProblem.from_url('http://codeforces.com/gym/101021/problem/A').contest_id, 101021)
         self.assertEqual(CodeforcesProblem.from_url('http://codeforces.com/gym/101021/problem/A').index, 'A')
+        self.assertEqual(CodeforcesProblem.from_url('https://codeforces.com/contest/1080/problem/A').contest_id, 1080)
+        self.assertEqual(CodeforcesProblem.from_url('https://codeforces.com/contest/1080/problem/A').index, 'A')
         self.assertEqual(CodeforcesProblem.from_url('https://codeforces.com/contest/1080/problem/A').contest_id, 1080)
         self.assertEqual(CodeforcesProblem.from_url('https://codeforces.com/contest/1080/problem/A').index, 'A')
         self.assertIsNone(CodeforcesProblem.from_url('https://atcoder.jp/contests/abc120/tasks/abc120_c'))


### PR DESCRIPTION
Codeforces EDU problems use a different URL pattern. Add support for this.

No support yet for getting contest (lesson) details for an EDU problem