### PR TITLE
Support atcoder parsing for admins

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -575,6 +575,7 @@ class AtCoderProblemData(ProblemData):
         else:
             assert False
 
+        # When login as the admin, a link is added after memory limit. See https://github.com/online-judge-tools/api-client/issues/90
         parsed_memory_limit = re.search(r'^(メモリ制限|Memory Limit): ([0-9.]+) (KB|MB)', memory_limit)
         assert parsed_memory_limit
 

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -1001,12 +1001,12 @@ class AtCoderSubmissionData(SubmissionData):
     @classmethod
     def _from_table_row(cls, tr: bs4.Tag, *, session: requests.Session, response: requests.Response, timestamp: datetime.datetime) -> 'AtCoderSubmissionData':
         tds = tr.find_all('td')
-        assert len(tds) in (8, 11)
+        if len(tds) % 2:
+            tds = tds[1:]
+        assert len(tds) in (8, 10)
 
         submission = AtCoderSubmission.from_url('https://atcoder.jp' + tds[-1].find('a')['href'])
         problem = AtCoderProblem.from_url('https://atcoder.jp' + tds[1].find('a')['href'])
-        if not problem:
-            problem = AtCoderProblem.from_url('https://atcoder.jp' + tds[2].find('a')['href'])
         assert submission is not None
         assert problem is not None
 

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -583,7 +583,7 @@ class AtCoderProblemData(ProblemData):
         if memory_limit_unit == 'KB':
             memory_limit_byte = int(float(memory_limit_value) * 1000)
         elif memory_limit_unit == 'MB':
-            memory_limit_byte = int(float(memory_limit_value) * 1000)
+            memory_limit_byte = int(float(memory_limit_value) * 1000 * 1000)
         else:
             assert False
 

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -1001,10 +1001,12 @@ class AtCoderSubmissionData(SubmissionData):
     @classmethod
     def _from_table_row(cls, tr: bs4.Tag, *, session: requests.Session, response: requests.Response, timestamp: datetime.datetime) -> 'AtCoderSubmissionData':
         tds = tr.find_all('td')
-        assert len(tds) in (8, 10)
+        assert len(tds) in (8, 11)
 
         submission = AtCoderSubmission.from_url('https://atcoder.jp' + tds[-1].find('a')['href'])
         problem = AtCoderProblem.from_url('https://atcoder.jp' + tds[1].find('a')['href'])
+        if not problem:
+            problem = AtCoderProblem.from_url('https://atcoder.jp' + tds[2].find('a')['href'])
         assert submission is not None
         assert problem is not None
 

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -575,15 +575,15 @@ class AtCoderProblemData(ProblemData):
         else:
             assert False
 
-        for memory_limit_prefix in ('メモリ制限: ', 'Memory Limit: '):
-            if memory_limit.startswith(memory_limit_prefix):
-                break
-        else:
-            assert False
-        if memory_limit.endswith(' KB'):
-            memory_limit_byte = int(float(utils.remove_suffix(utils.remove_prefix(memory_limit, memory_limit_prefix), ' KB')) * 1000)
-        elif memory_limit.endswith(' MB'):
-            memory_limit_byte = int(float(utils.remove_suffix(utils.remove_prefix(memory_limit, memory_limit_prefix), ' MB')) * 1000 * 1000)
+        parsed_memory_limit = re.search(r'^(メモリ制限|Memory Limit): ([0-9.]+) (KB|MB)', memory_limit)
+        assert parsed_memory_limit
+
+        memory_limit_value = parsed_memory_limit.group(2)
+        memory_limit_unit = parsed_memory_limit.group(3)
+        if memory_limit_unit == 'KB':
+            memory_limit_byte = int(float(memory_limit_value) * 1000)
+        elif memory_limit_unit == 'MB':
+            memory_limit_byte = int(float(memory_limit_value) * 1000)
         else:
             assert False
 

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -1002,6 +1002,7 @@ class AtCoderSubmissionData(SubmissionData):
     def _from_table_row(cls, tr: bs4.Tag, *, session: requests.Session, response: requests.Response, timestamp: datetime.datetime) -> 'AtCoderSubmissionData':
         tds = tr.find_all('td')
         if len(tds) % 2:
+            # when login as the admin, we have one more extra column.
             tds = tds[1:]
         assert len(tds) in (8, 10)
 


### PR DESCRIPTION
fix #90

2つ変更しました。

1つ目はmemory limitのparseの修正です。issueに書いたとおり、adminだと"メモリ制限: 1024 MB" の後ろに余分な文字列が付くので、parseを少しロバストにしました。
<img width="353" alt="スクリーンショット 2020-08-24 20 17 43" src="https://user-images.githubusercontent.com/7629145/91040210-cc6dc080-e648-11ea-983e-72b74115032a.png">


2つ目はsubmission listのページのパースの修正です。adminだと"2020-08-24 20:18:21"という時刻のcolumnの前にもう一つチェックボックスを格納したcolumnが生まれ、assertが落ちてしまいます。どう直そうか悩んだのですが、とりあえず一番変更量が少なくなりそうな直し方をしました。 <img width="1104" alt="スクリーンショット 2020-08-24 20 18 55" src="https://user-images.githubusercontent.com/7629145/91040187-c4158580-e648-11ea-8d24-f8ec8c4265ec.png">



どちらも手元での動作は確認しています。
