### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
 
     - name: Install dependencies
       run: pip3 install .[dev]

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,6 +11,8 @@ jobs:
 
     - name: Set up Python
       uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
 
     - name: Install dependencies
       run: pip3 install .[dev]

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,6 +13,8 @@ jobs:
 
     - name: Set up Python
       uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test-unstable-workaround-macos.yml
+++ b/.github/workflows/test-unstable-workaround-macos.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.5
 

--- a/.github/workflows/test-unstable-workaround-macos.yml
+++ b/.github/workflows/test-unstable-workaround-macos.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/test-unstable-workaround-ubuntu.yml
+++ b/.github/workflows/test-unstable-workaround-ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.5
 

--- a/.github/workflows/test-unstable-workaround-ubuntu.yml
+++ b/.github/workflows/test-unstable-workaround-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/test-unstable-workaround-windows.yml
+++ b/.github/workflows/test-unstable-workaround-windows.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.5
 

--- a/.github/workflows/test-unstable-workaround-windows.yml
+++ b/.github/workflows/test-unstable-workaround-windows.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python
       uses: actions/setup-python@v1


### PR DESCRIPTION
Bump versions of actions.
This contains a workaround for the `lxml` issue.

related: https://github.com/online-judge-tools/verification-helper/issues/335
cc: @usk83 for https://github.com/online-judge-tools/api-client/pull/114