### PR TITLE
fix HackerRank submission

### DIFF
--- a/onlinejudge/service/hackerrank.py
+++ b/onlinejudge/service/hackerrank.py
@@ -159,7 +159,7 @@ class HackerRankProblem(onlinejudge.type.Problem):
         csrftoken = soup.find('meta', attrs={'name': 'csrf-token'}).attrs['content']
         # post
         url = 'https://www.hackerrank.com/rest/contests/{}/challenges/{}/submissions'.format(self.contest_slug, self.challenge_slug)
-        payload = {'code': code, 'language': str(language_id), 'contest_slug': self.contest_slug}
+        payload = {'code': code.decode('utf-8'), 'language': str(language_id), 'contest_slug': self.contest_slug}
         logger.debug('payload: %s', payload)
         resp = utils.request('POST', url, session=session, json=payload, headers={'X-CSRF-Token': csrftoken})
         # parse


### PR DESCRIPTION
### Problem

When this tool submit code to HackerRank, the tool throws the following error.

```
[ERROR] Object of type bytes is not JSON serializable
Traceback (most recent call last):
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/onlinejudge_command/main.py", line 271, in main
    run_program(parsed, parser=parser)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/onlinejudge_command/main.py", line 241, in run_program
    submit(args)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/onlinejudge_command/subcommand/submit.py", line 136, in submit
    submission = problem.submit_code(code, language_id=LanguageId(args.language), session=sess)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/onlinejudge/service/hackerrank.py", line 164, in submit_code
    resp = utils.request('POST', url, session=session, json=payload, headers={'X-CSRF-Token': csrftoken})
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/onlinejudge/_implementation/utils.py", line 175, in request
    resp = session.request(method, url, **kwargs)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/requests/sessions.py", line 516, in request
    prep = self.prepare_request(req)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/requests/sessions.py", line 449, in prepare_request
    p.prepare(
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/requests/models.py", line 317, in prepare
    self.prepare_body(data, files, json)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/site-packages/requests/models.py", line 467, in prepare_body
    body = complexjson.dumps(json)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/Users/koichi.ishida/.anyenv/envs/pyenv/versions/3.8.2/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```

### What this PR have done

This code change variable code type from bytes to string. I successfully submit it to HackerRank.

(Python 3.8.2)
