### PR TITLE
[AtCoder] Fix problem logging wrong folder

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -913,7 +913,7 @@ class AtCoderProblem(onlinejudge.type.Problem):
                 contest_folder = entry
         if contest_folder is None:
             raise SampleParseError('no folder matches the contest')
-        logger.info('contest folder found: %s', entry)
+        logger.info('contest folder found: %s', contest_folder)
 
         # list folders
         path = "/{}".format(contest_folder['name'])


### PR DESCRIPTION
Fixes the problem where logging the wrong folder as a found folder when downloading system test cases for atcoder.