### PR TITLE
Remove toml from requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         'colorlog >= 4.1.0',
         'lxml >= 4',
         'requests >= 2',
-        'toml >= 0.10',
         'jsonschema >= 3.2',
     ],
     packages=find_packages(exclude=('tests', 'docs')),


### PR DESCRIPTION
[yosupo06/library-checker-problems](https://github.com/yosupo06/library-checker-problems) を実行するために `toml` パッケージをインポートしていますが、最新版では不要になっています。

Latest  yosupo06/library-checker-problems doesn't require toml package.

https://github.com/yosupo06/library-checker-problems/pull/801