### PR TITLE
Allow user_data_dir and user_cache_dir to be overridden by environment variables.

### DIFF
--- a/onlinejudge/utils.py
+++ b/onlinejudge/utils.py
@@ -5,6 +5,7 @@ the module for those who make programs using online-judge-tools as a library
 
 import contextlib
 import http
+import os
 import pathlib
 from logging import getLogger
 from typing import *
@@ -15,8 +16,8 @@ from onlinejudge.type import *
 
 logger = getLogger(__name__)
 
-user_data_dir = pathlib.Path(appdirs.user_data_dir('online-judge-tools'))
-user_cache_dir = pathlib.Path(appdirs.user_cache_dir('online-judge-tools'))
+user_data_dir = pathlib.Path(os.getenv('ONLINE_JUDGE_TOOLS_DATA_DIR', appdirs.user_data_dir('online-judge-tools')))
+user_cache_dir = pathlib.Path(os.getenv('ONLINE_JUDGE_TOOLS_CACHE_DIR', appdirs.user_cache_dir('online-judge-tools')))
 
 _DEFAULT_SESSION = None  # Optional[requests.Session]
 


### PR DESCRIPTION
`user_data_dir` と `user_cache_dir` をそれぞれ環境変数 `ONLINE_JUDGE_TOOLS_DATA_DIR`, `ONLINE_JUDGE_TOOLS_CACHE_DIR` で上書きできるようにしました。

https://github.com/online-judge-tools/verification-helper/issues/394 でキャッシュを削除できるようにしたいという要望があったり、- https://github.com/competitive-verifier/competitive-verifier でむりやり書き換えて使用していたりするのをユーザーがカスタムできるようになるので多少の改善になるかなと思います。