### PR TITLE
add elixir extensions

### DIFF
--- a/onlinejudge/_implementation/language_guessing.py
+++ b/onlinejudge/_implementation/language_guessing.py
@@ -193,6 +193,7 @@ other_languages_table: List[Dict[str, Any]] = [
      { 'names': [ 'common lisp'           ], 'exts': [ 'lisp', 'lsp', 'cl' ] },
      { 'names': [ 'crystal'               ], 'exts': [ 'cr'        ] },
      { 'names': [ 'd'                     ], 'exts': [ 'd'         ], 'split': True },
+     { 'names': [ 'elixir'                ], 'exts': [ 'ex', 'exs' ] },
      { 'names': [ 'f#'                    ], 'exts': [ 'fs'        ] },
      { 'names': [ 'fortran'               ], 'exts': [ 'for', 'f', 'f90', 'f95', 'f03' ] },
      { 'names': [ 'go'                    ], 'exts': [ 'go'        ], 'split': True },


### PR DESCRIPTION
## 概要
language_guessing に elixir が入ってなかったので追加しました。差し支えなければマージしてくださると 🙏 

## 動作確認
以下のコマンドとその結果を確認した

diff入れる前

```sh
oj-api guess-language-id --file main.exs https://atcoder.jp/contests/agc001/tasks/agc001_a
{"status": "error", "messages": ["RuntimeError: no language id found"], "result": null}
```

diff入れた後

```sh
oj-api guess-language-id --file main.exs https://atcoder.jp/contests/agc001/tasks/agc001_a
{"status": "ok", "messages": [], "result": {"id": "5085", "description": "Elixir (Elixir 1.15.2)", "context": {"problem": {"url": "https://atcoder.jp/contests/agc001/tasks/agc001_a"}}}}
```