### PR TITLE
Fix/atcoder memory notation change

### DIFF
--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -542,10 +542,10 @@ class AtCoderProblemData(ProblemData):
             time_limit_msec = int(float(utils.remove_suffix(tds[2].text, ' sec')) * 1000)
         else:
             assert False
-        if tds[3].text.endswith(' KB'):
-            memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' KB')) * 1000)
-        elif tds[3].text.endswith(' MB'):
-            memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' MB')) * 1000 * 1000)  # TODO: confirm this is MB truly, not MiB
+        if tds[3].text.endswith(' KiB'):
+            memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' KiB')) * 1024)
+        elif tds[3].text.endswith(' MiB'):
+            memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' MiB')) * 1024 * 1024)  # TODO: confirm this is MB truly, not MiB
         else:
             assert False
         if len(tds) == 5:
@@ -583,15 +583,15 @@ class AtCoderProblemData(ProblemData):
             assert False
 
         # When login as the admin, a link is added after memory limit. See https://github.com/online-judge-tools/api-client/issues/90
-        parsed_memory_limit = re.search(r'^(メモリ制限|Memory Limit): ([0-9.]+) (KB|MB)', memory_limit)
+        parsed_memory_limit = re.search(r'^(メモリ制限|Memory Limit): ([0-9.]+) (KiB|MiB)', memory_limit)
         assert parsed_memory_limit
 
         memory_limit_value = parsed_memory_limit.group(2)
         memory_limit_unit = parsed_memory_limit.group(3)
-        if memory_limit_unit == 'KB':
-            memory_limit_byte = int(float(memory_limit_value) * 1000)
-        elif memory_limit_unit == 'MB':
-            memory_limit_byte = int(float(memory_limit_value) * 1000 * 1000)
+        if memory_limit_unit == 'KiB':
+            memory_limit_byte = int(float(memory_limit_value) * 1024)
+        elif memory_limit_unit == 'MiB':
+            memory_limit_byte = int(float(memory_limit_value) * 1024 * 1024)
         else:
             assert False
 
@@ -1160,7 +1160,7 @@ class AtCoderSubmissionData(SubmissionData):
         status = tds[6].text
         if len(tds) == 10:
             exec_time_msec = int(utils.remove_suffix(tds[7].text, ' ms'))  # type: Optional[int]
-            memory_byte = int(utils.remove_suffix(tds[8].text, ' KB')) * 1000  # type: Optional[int]
+            memory_byte = int(utils.remove_suffix(tds[8].text, ' KiB')) * 1024  # type: Optional[int]
         else:
             exec_time_msec = None
             memory_byte = None

--- a/onlinejudge_api/get_problem.py
+++ b/onlinejudge_api/get_problem.py
@@ -67,7 +67,7 @@ schema = {
         },
         "memoryLimit": {
             "type": "integer",
-            "description": "in megabytes (MB), not in mebibytes (MiB); Decimals are truncated for compatibility to competitive-companion",
+            "description": "in mebibytes (MiB), not in megabytes (MB); Decimals are truncated for compatibility to competitive-companion",
         },
         "timeLimit": {
             "type": "integer",
@@ -316,7 +316,7 @@ def main(problem: Problem, *, is_system: bool, is_compatibility: bool, is_full: 
             },
             "alphabet": data.alphabet,
         }
-        result["memoryLimit"] = data.memory_limit_byte // 1000 // 1000
+        result["memoryLimit"] = data.memory_limit_byte // 1024 // 1024
         result["timeLimit"] = data.time_limit_msec
         if is_full:
             result["raw"] = {

--- a/tests/service_atcoder.py
+++ b/tests/service_atcoder.py
@@ -84,7 +84,7 @@ class AtCoderContestTest(unittest.TestCase):
         time.sleep(0.5)
         self.assertEqual(problems[0].download_data().time_limit_msec, 2000)
         time.sleep(0.5)
-        self.assertEqual(problems[0].download_data().memory_limit_byte, 1024 * 1000 * 1000)
+        self.assertEqual(problems[0].download_data().memory_limit_byte, 1024 * 1024 * 1024)
         time.sleep(0.5)
         self.assertEqual(problems[5].download_data().alphabet, 'F')
         time.sleep(0.5)
@@ -106,11 +106,11 @@ class AtCoderContestTest(unittest.TestCase):
         time.sleep(0.5)
         self.assertEqual(problems[0].download_data().time_limit_msec, 2525)
         time.sleep(0.5)
-        self.assertEqual(problems[0].download_data().memory_limit_byte, 246 * 1000 * 1000)
+        self.assertEqual(problems[0].download_data().memory_limit_byte, 246 * 1024 * 1024)
         time.sleep(0.5)
         self.assertEqual(problems[1].download_data().time_limit_msec, 5252)
         time.sleep(0.5)
-        self.assertEqual(problems[1].download_data().memory_limit_byte, 512 * 1000 * 1000)
+        self.assertEqual(problems[1].download_data().memory_limit_byte, 512 * 1024 * 1024)
 
     def test_list_problems_time_limit_is_less_than_msec(self):
         contest = AtCoderContest.from_url('https://atcoder.jp/contests/joi2019ho')
@@ -132,9 +132,9 @@ class AtCoderContestTest(unittest.TestCase):
         time.sleep(0.5)
         problems = contest.list_problems()
         time.sleep(0.5)
-        self.assertEqual(problems[0].download_data().memory_limit_byte, 1024 * 1000 * 1000)  # 1024 MB
+        self.assertEqual(problems[0].download_data().memory_limit_byte, 1024 * 1024 * 1024)  # 1024 MiB
         time.sleep(0.5)
-        self.assertEqual(problems[1].download_data().memory_limit_byte, 0)  # 0 KB
+        self.assertEqual(problems[1].download_data().memory_limit_byte, 0)  # 0 KiB
 
     @unittest.skip('Breaking change in AtCoder')
     def test_iterate_submissions(self):
@@ -195,7 +195,7 @@ class AtCoderProblemTest(unittest.TestCase):
         self.assertEqual(data.alphabet, 'A')
         self.assertEqual(data.name, 'B +/- A')
         self.assertEqual(data.time_limit_msec, 2000)
-        self.assertEqual(data.memory_limit_byte, 1024 * 1000 * 1000)
+        self.assertEqual(data.memory_limit_byte, 1024 * 1024 * 1024)
         self.assertEqual(data.score, 100)
 
     def test_get_alphabet(self):
@@ -259,7 +259,7 @@ class AtCoderProblemDataTest(unittest.TestCase):
         self.assertEqual(data.available_languages, None)
         self.assertEqual(data.html, html)
         self.assertEqual(data.input_format, None)
-        self.assertEqual(data.memory_limit_byte, 292 * 1000 * 1000)
+        self.assertEqual(data.memory_limit_byte, 292 * 1024 * 1024)
         self.assertEqual(data.name, 'プログラミングコンテスト')
         self.assertEqual(data.problem, AtCoderProblem.from_url(url))
         self.assertEqual(data.sample_cases, [
@@ -281,7 +281,7 @@ class AtCoderProblemDataTest(unittest.TestCase):
         self.assertEqual(data.available_languages, None)
         self.assertEqual(data.html, html)
         self.assertEqual(data.input_format, '\r\n<var>R</var> <var>C</var>\r\n<var>X</var> <var>Y</var>\r\n<var>D</var> <var>L</var>\r\n')
-        self.assertEqual(data.memory_limit_byte, 64 * 1000 * 1000)
+        self.assertEqual(data.memory_limit_byte, 64 * 1024 * 1024)
         self.assertEqual(data.name, 'AtCoder社の冬')
         self.assertEqual(data.problem, AtCoderProblem.from_url(url))
         self.assertEqual(data.sample_cases, [
@@ -304,7 +304,7 @@ class AtCoderProblemDataTest(unittest.TestCase):
         self.assertEqual(data.available_languages, None)
         self.assertEqual(data.html, html)
         self.assertEqual(data.input_format, '<var>N</var>\r\n')
-        self.assertEqual(data.memory_limit_byte, 1024 * 1000 * 1000)
+        self.assertEqual(data.memory_limit_byte, 1024 * 1024 * 1024)
         self.assertEqual(data.name, '756')
         self.assertEqual(data.problem, AtCoderProblem.from_url(url))
         self.assertEqual(data.sample_cases, [
@@ -326,7 +326,7 @@ class AtCoderProblemDataTest(unittest.TestCase):
         self.assertEqual(data.available_languages, None)
         self.assertEqual(data.html, html)
         self.assertEqual(data.input_format, '<var>N</var> <var>K</var>\r\n<var>A_0</var> <var>A_1</var> <var>\\cdots</var> <var>A_{N-1}</var>\r\n')
-        self.assertEqual(data.memory_limit_byte, 1024 * 1000 * 1000)
+        self.assertEqual(data.memory_limit_byte, 1024 * 1024 * 1024)
         self.assertEqual(data.name, 'Do Not Duplicate')
         self.assertEqual(data.problem, AtCoderProblem.from_url(url))
         self.assertEqual(data.sample_cases, [
@@ -349,7 +349,7 @@ class AtCoderProblemDataTest(unittest.TestCase):
         self.assertEqual(data.available_languages, None)
         self.assertEqual(data.html, html)
         self.assertEqual(data.input_format, None)
-        self.assertEqual(data.memory_limit_byte, 64 * 1000 * 1000)
+        self.assertEqual(data.memory_limit_byte, 64 * 1024 * 1024)
         self.assertEqual(data.name, '天下一株式会社採用情報')
         self.assertEqual(data.problem, AtCoderProblem.from_url(url))
         self.assertEqual(data.sample_cases, [])
@@ -367,7 +367,7 @@ class AtCoderProblemDataTest(unittest.TestCase):
         self.assertEqual(data.available_languages, None)
         self.assertEqual(data.html, html)
         self.assertEqual(data.input_format, None)
-        self.assertEqual(data.memory_limit_byte, 256 * 1000 * 1000)
+        self.assertEqual(data.memory_limit_byte, 256 * 1024 * 1024)
         self.assertEqual(data.name, 'Graph Cut')
         self.assertEqual(data.problem, AtCoderProblem.from_url(url))
         self.assertEqual(data.sample_cases, [


### PR DESCRIPTION
# what
#172 について、メモリ表記と、計算値を変更しました。
KB→KiB (byte * 1000 → byte * 1024)
MB→MiB(byte * 1000 * 1000 → byte * 1024 * 1024)
あったらごめんなさいなのですが、このプロジェクト内ではテスト時の```[INFO]max memory: ○○MiB```
を出力する箇所が見つけられなかったのでこの範囲の変更のみ行っています。

# why
- AtCoderProblemDataを呼び出した際にAssertionErrorで動作が止まるため
- メモリ制限の表記変更に伴い、内部的な計算も変化するため

お手すきの際に確認していただけると幸いです。