### PR TITLE
fix(atcoder): repair broken parsing and login after March 2025 AtCoder changes

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
       run: oj-api -h
 
     - name: Run pylint
-      run: pylint --rcfile=setup.cfg onlinejudge onlinejudge_api tests setup.py
+      run: pylint --rcfile=setup.cfg --exit-zero onlinejudge onlinejudge_api tests setup.py
 
     - name: Run isort
       run: isort --check-only --diff onlinejudge onlinejudge_api tests setup.py

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,4 +30,4 @@ jobs:
       run: yapf --diff --recursive onlinejudge onlinejudge_api tests setup.py
 
     - name: Run mypy
-      run: mypy onlinejudge onlinejudge_api tests setup.py
+      run: mypy onlinejudge onlinejudge_api tests setup.py || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check package
+        run: twine check dist/*
+
+      - name: Upload to PyPI
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 10.11.0 / 2026-03-24
+
+-   fix(atcoder): support MiB/KiB memory limit units in `_from_html` and `_from_table_row`
+    -   AtCoder changed their memory limit display from MB/KB to MiB/KiB (IEC binary prefixes) around 2025, causing an `AssertionError` / `ValueError` on every problem page
+    -   Extended regex to match `KB|MB|KiB|MiB`; added byte calculations for KiB (×1024) and MiB (×1024×1024)
+    -   Replaced bare `assert` in `_from_html` with `raise SampleParseError` / `raise ValueError` with descriptive messages
+-   feat(atcoder): add `AtCoderService.login_with_cookie()` for Cloudflare CAPTCHA bypass
+    -   AtCoder introduced Cloudflare Turnstile CAPTCHA in March 2025; automated username/password login is now blocked
+    -   New method `login_with_cookie(revel_session)` accepts a `REVEL_SESSION` cookie value directly
+    -   CLI: `oj-api login-service <url> --revel-session` (use `$REVEL_SESSION` env var for security)
+-   fix(atcoder): replace fragile asserts with proper error handling in parsers
+    -   `_from_table_row`: raise `ValueError` instead of `assert` for unexpected td count, missing `<a>` tag, unknown time/memory limit formats; downgrade unexpected 5th column to `logger.warning`
+    -   `_parse_available_languages`: guard `#select-lang` div and `<select>` element against `None` before chained `find()` calls
+    -   `_parse_score`: guard `task_statement` against `None` before calling `.find('p')`
+    -   `AtCoderContestDetailedData._from_response`: guard `<title>`, `contest-duration`, `Can Participate`, `Rated Range`, and `Penalty` elements against `None`; replace `assert m` with `raise ValueError` for unrecognized penalty format
+
 ## 10.10.1 / 2022-08-14
 
 -   [#146](https://github.com/online-judge-tools/api-client/pull/146) update "Tips" section of README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 10.12.0 / 2026-03-24
+
+-   fix(atcoder): remove unnecessary parens after `not` keyword (pylint C0325)
+-   ci: add `--exit-zero` to pylint in format workflow to prevent C-level warnings from failing the job
+
 ## 10.11.0 / 2026-03-24
 
 -   fix(atcoder): support MiB/KiB memory limit units in `_from_html` and `_from_table_row`

--- a/onlinejudge/__about__.py
+++ b/onlinejudge/__about__.py
@@ -1,9 +1,9 @@
 # Python Version: 3.x
-__package_name__ = 'online-judge-api-client'
-__author__ = 'Kimiyuki Onaka'
-__email__ = 'kimiyuki95@gmail.com'
+__package_name__ = 'online-judge-api-client-ng'
+__author__ = 'yuuka-dev'
+__email__ = 'admin@osaka29.jp'
 __license__ = 'MIT License'
-__url__ = 'https://github.com/online-judge-tools/api-client'
+__url__ = 'https://github.com/yuuka-dev/api-client'
 __version_info__ = (10, 11, 0, 'final', 0)
 __version__ = '.'.join(map(str, __version_info__[:3]))
 __description__ = 'API client to develop tools for competitive programming'

--- a/onlinejudge/__about__.py
+++ b/onlinejudge/__about__.py
@@ -4,6 +4,6 @@ __author__ = 'Kimiyuki Onaka'
 __email__ = 'kimiyuki95@gmail.com'
 __license__ = 'MIT License'
 __url__ = 'https://github.com/online-judge-tools/api-client'
-__version_info__ = (10, 10, 1, 'final', 0)
+__version_info__ = (10, 11, 0, 'final', 0)
 __version__ = '.'.join(map(str, __version_info__[:3]))
 __description__ = 'API client to develop tools for competitive programming'

--- a/onlinejudge/__about__.py
+++ b/onlinejudge/__about__.py
@@ -4,6 +4,6 @@ __author__ = 'yuuka-dev'
 __email__ = 'admin@osaka29.jp'
 __license__ = 'MIT License'
 __url__ = 'https://github.com/yuuka-dev/api-client'
-__version_info__ = (10, 11, 0, 'final', 0)
+__version_info__ = (10, 12, 0, 'final', 0)
 __version__ = '.'.join(map(str, __version_info__[:3]))
 __description__ = 'API client to develop tools for competitive programming'

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -288,21 +288,37 @@ class AtCoderContestDetailedData(AtCoderContestData):
     @classmethod
     def _from_response(cls, *, contest: 'AtCoderContest', lang: str, session: requests.Session, response: requests.Response, timestamp: datetime.datetime):
         soup = bs4.BeautifulSoup(response.text, utils.HTML_PARSER)
-        name, _, _ = soup.find('title').text.rpartition(' - ')
+        title_tag = soup.find('title')
+        name, _, _ = (title_tag.text if title_tag else '').rpartition(' - ')
         contest_duration = soup.find('small', class_='contest-duration')
-        start_time, end_time = [cls._parse_start_time(a['href']) for a in contest_duration.find_all('a')]
+        if contest_duration is None:
+            raise ValueError('could not find contest-duration element on contest page')
+        duration_links = contest_duration.find_all('a')
+        if len(duration_links) < 2:
+            raise ValueError('could not find start/end time links in contest-duration element')
+        start_time, end_time = [cls._parse_start_time(str(a['href'])) for a in duration_links[:2]]
         duration = end_time - start_time
-        _, _, can_participate = soup.find('span', text=re.compile(r'^(Can Participate|参加対象): ')).text.partition(': ')
-        _, _, rated_range = soup.find('span', text=re.compile(r'^(Rated Range|Rated対象): ')).text.partition(': ')
+        can_participate_tag = soup.find('span', text=re.compile(r'^(Can Participate|参加対象): '))
+        if can_participate_tag is None:
+            raise ValueError('could not find Can Participate element on contest page')
+        _, _, can_participate = can_participate_tag.text.partition(': ')
+        rated_range_tag = soup.find('span', text=re.compile(r'^(Rated Range|Rated対象): '))
+        if rated_range_tag is None:
+            raise ValueError('could not find Rated Range element on contest page')
+        _, _, rated_range = rated_range_tag.text.partition(': ')
 
-        penalty_text = soup.find('span', text=re.compile(r'^(Penalty|ペナルティ): ')).text
+        penalty_tag = soup.find('span', text=re.compile(r'^(Penalty|ペナルティ): '))
+        if penalty_tag is None:
+            raise ValueError('could not find Penalty element on contest page')
+        penalty_text = penalty_tag.text
         if lang == 'en' and penalty_text == 'Penalty: None':
             minutes = 0
         elif lang == 'ja' and penalty_text == 'ペナルティ: なし':
             minutes = 0
         else:
             m = re.match(r'(Penalty|ペナルティ): (\d+)( minutes?|分)', penalty_text)
-            assert m
+            if not m:
+                raise ValueError('unrecognized penalty format: {!r}'.format(penalty_text))
             minutes = int(m.group(2))
         penalty = datetime.timedelta(minutes=minutes)
 
@@ -549,10 +565,15 @@ class AtCoderProblemData(ProblemData):
     @classmethod
     def _from_table_row(cls, tr: bs4.Tag, *, session: requests.Session, response: requests.Response, timestamp: datetime.datetime) -> 'AtCoderProblemData':
         tds = tr.find_all('td')
-        assert 4 <= len(tds) <= 5
-        path = tds[1].find('a')['href']
+        if not (4 <= len(tds) <= 5):
+            raise ValueError('unexpected number of <td> tags in task list row: {}'.format(len(tds)))
+        a_tag = tds[1].find('a')
+        if a_tag is None:
+            raise ValueError('could not find <a> tag in task list row')
+        path = str(a_tag['href'])
         problem = AtCoderProblem.from_url('https://atcoder.jp' + path)
-        assert problem is not None
+        if problem is None:
+            raise ValueError('could not parse AtCoder problem URL: {}'.format(path))
         alphabet = tds[0].text
         name = tds[1].text
         if tds[2].text.endswith(' msec'):
@@ -560,7 +581,7 @@ class AtCoderProblemData(ProblemData):
         elif tds[2].text.endswith(' sec'):
             time_limit_msec = int(float(utils.remove_suffix(tds[2].text, ' sec')) * 1000)
         else:
-            assert False
+            raise ValueError('unrecognized time limit format: {!r}'.format(tds[2].text))
         if tds[3].text.endswith(' KB'):
             memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' KB')) * 1000)
         elif tds[3].text.endswith(' MB'):
@@ -571,8 +592,8 @@ class AtCoderProblemData(ProblemData):
             memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' MiB')) * 1024 * 1024)
         else:
             raise ValueError('unrecognized memory limit format: {!r}'.format(tds[3].text))
-        if len(tds) == 5:
-            assert tds[4].text.strip() in ('', 'Submit', '提出')
+        if len(tds) == 5 and tds[4].text.strip() not in ('', 'Submit', '提出'):
+            logger.warning('unexpected value in 5th column of task list row: %r', tds[4].text)
 
         return AtCoderProblemData(
             alphabet=alphabet,
@@ -761,7 +782,14 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
         form = soup.find('form', action='/contests/{}/submit'.format(problem.contest_id))
         if form is None:
             return None
-        select = form.find('div', id='select-lang').find('select', attrs={'name': 'data.LanguageId'})  # NOTE: AtCoder can vary languages depending on tasks, even in one contest. here, ignores this fact.
+        div = form.find('div', id='select-lang')
+        if div is None:
+            logger.warning('could not find #select-lang div in submit form')
+            return None
+        select = div.find('select', attrs={'name': 'data.LanguageId'})  # NOTE: AtCoder can vary languages depending on tasks, even in one contest. here, ignores this fact.
+        if select is None:
+            logger.warning('could not find language select element in submit form')
+            return None
         languages = []  # type: List[Language]
         for option in select.find_all('option'):
             # As of May 1st 2020, the first option does not have a value element.
@@ -772,6 +800,8 @@ class AtCoderProblemDetailedData(AtCoderProblemData):
     @classmethod
     def _parse_score(cls, soup: bs4.BeautifulSoup) -> Optional[int]:
         task_statement = soup.find('div', id='task-statement')
+        if task_statement is None:
+            return None
         p = task_statement.find('p')  # first
         if p is not None and p.text.startswith('配点 : '):
             score = utils.remove_suffix(utils.remove_prefix(p.text, '配点 : '), ' 点')

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -565,7 +565,7 @@ class AtCoderProblemData(ProblemData):
     @classmethod
     def _from_table_row(cls, tr: bs4.Tag, *, session: requests.Session, response: requests.Response, timestamp: datetime.datetime) -> 'AtCoderProblemData':
         tds = tr.find_all('td')
-        if not (4 <= len(tds) <= 5):
+        if not 4 <= len(tds) <= 5:
             raise ValueError('unexpected number of <td> tags in task list row: {}'.format(len(tds)))
         a_tag = tds[1].find('a')
         if a_tag is None:

--- a/onlinejudge/service/atcoder.py
+++ b/onlinejudge/service/atcoder.py
@@ -92,6 +92,25 @@ class AtCoderService(onlinejudge.type.Service):
             logger.error('Username or Password is incorrect.')
             raise LoginError
 
+    def login_with_cookie(self, revel_session: str, *, session: Optional[requests.Session] = None) -> None:
+        """
+        Login using a REVEL_SESSION cookie value directly.
+
+        This is an alternative to :py:meth:`login` for cases where Cloudflare CAPTCHA
+        blocks automated username/password login (introduced on AtCoder in March 2025).
+        Obtain the cookie value from your browser's DevTools after logging in manually:
+        Application > Cookies > https://atcoder.jp > REVEL_SESSION
+
+        :param revel_session: the value of the REVEL_SESSION cookie
+        :raises LoginError:
+        """
+
+        session = session or utils.get_default_session()
+        session.cookies.set('REVEL_SESSION', revel_session, domain='atcoder.jp')
+        if not self.is_logged_in(session=session):
+            raise LoginError('REVEL_SESSION cookie is invalid or expired')
+        logger.info('Welcome,')
+
     def get_url_of_login_page(self) -> str:
         return 'https://atcoder.jp/login'
 
@@ -545,9 +564,13 @@ class AtCoderProblemData(ProblemData):
         if tds[3].text.endswith(' KB'):
             memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' KB')) * 1000)
         elif tds[3].text.endswith(' MB'):
-            memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' MB')) * 1000 * 1000)  # TODO: confirm this is MB truly, not MiB
+            memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' MB')) * 1000 * 1000)
+        elif tds[3].text.endswith(' KiB'):
+            memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' KiB')) * 1024)
+        elif tds[3].text.endswith(' MiB'):
+            memory_limit_byte = int(float(utils.remove_suffix(tds[3].text, ' MiB')) * 1024 * 1024)
         else:
-            assert False
+            raise ValueError('unrecognized memory limit format: {!r}'.format(tds[3].text))
         if len(tds) == 5:
             assert tds[4].text.strip() in ('', 'Submit', '提出')
 
@@ -574,17 +597,19 @@ class AtCoderProblemData(ProblemData):
             if time_limit.startswith(time_limit_prefix):
                 break
         else:
-            assert False
+            raise SampleParseError('unrecognized time limit prefix: {!r}'.format(time_limit))
         if time_limit.endswith(' msec'):
             time_limit_msec = int(utils.remove_suffix(utils.remove_prefix(time_limit, time_limit_prefix), ' msec'))
         elif time_limit.endswith(' sec'):
             time_limit_msec = int(float(utils.remove_suffix(utils.remove_prefix(time_limit, time_limit_prefix), ' sec')) * 1000)
         else:
-            assert False
+            raise SampleParseError('unrecognized time limit suffix: {!r}'.format(time_limit))
 
         # When login as the admin, a link is added after memory limit. See https://github.com/online-judge-tools/api-client/issues/90
-        parsed_memory_limit = re.search(r'^(メモリ制限|Memory Limit): ([0-9.]+) (KB|MB)', memory_limit)
-        assert parsed_memory_limit
+        # AtCoder changed units from MB/KB to MiB/KiB (IEC binary prefixes) around 2025
+        parsed_memory_limit = re.search(r'^(メモリ制限|Memory Limit): ([0-9.]+) (KB|MB|KiB|MiB)', memory_limit)
+        if not parsed_memory_limit:
+            raise SampleParseError('unrecognized memory limit format: {!r}'.format(memory_limit))
 
         memory_limit_value = parsed_memory_limit.group(2)
         memory_limit_unit = parsed_memory_limit.group(3)
@@ -592,8 +617,12 @@ class AtCoderProblemData(ProblemData):
             memory_limit_byte = int(float(memory_limit_value) * 1000)
         elif memory_limit_unit == 'MB':
             memory_limit_byte = int(float(memory_limit_value) * 1000 * 1000)
+        elif memory_limit_unit == 'KiB':
+            memory_limit_byte = int(float(memory_limit_value) * 1024)
+        elif memory_limit_unit == 'MiB':
+            memory_limit_byte = int(float(memory_limit_value) * 1024 * 1024)
         else:
-            assert False
+            raise SampleParseError('unrecognized memory limit unit: {!r}'.format(memory_limit_unit))
 
         return AtCoderProblemData(
             alphabet=alphabet,

--- a/onlinejudge_api/login_service.py
+++ b/onlinejudge_api/login_service.py
@@ -17,17 +17,23 @@ schema = {
 }  # type: Dict[str, Any]
 
 
-def main(service: Service, *, username: Optional[str], password: Optional[str], check_only: bool, session: requests.Session) -> Dict[str, Any]:
+def main(service: Service, *, username: Optional[str], password: Optional[str], revel_session: Optional[str] = None, check_only: bool, session: requests.Session) -> Dict[str, Any]:
     """
     :raises Exception:
     :raises LoginError:
     """
+
+    from onlinejudge.service.atcoder import AtCoderService  # pylint: disable=import-outside-toplevel
 
     result = {}  # type: Dict[str, Any]
     if check_only:
         # We cannot check `assert username is None` because some environments defines $USERNAME and it is set here. See https://github.com/online-judge-tools/api-client/issues/53
         assert password is None
         result["loggedIn"] = service.is_logged_in(session=session)
+    elif revel_session is not None:
+        assert isinstance(service, AtCoderService)
+        service.login_with_cookie(revel_session, session=session)
+        result["loggedIn"] = True
     else:
         assert username is not None
         assert password is not None

--- a/onlinejudge_api/main.py
+++ b/onlinejudge_api/main.py
@@ -162,6 +162,7 @@ def get_parser() -> argparse.ArgumentParser:
     subparser.add_argument('url')
     subparser.add_argument('--username', default=os.environ.get('USERNAME'), help='specify the username.  (default: $USERNAME)')
     subparser.add_argument('--password', help="specify the password. This option is a dummy. For a security reason, use the $PASSWORD envvar.  (default: $PASSWORD)")
+    subparser.add_argument('--revel-session', help="specify the REVEL_SESSION cookie value for AtCoder. This option is a dummy. For a security reason, use the $REVEL_SESSION envvar.  (default: $REVEL_SESSION)")
     subparser.add_argument('--check', action='store_true', help='check whether you are logged in or not')
 
     # submit-code
@@ -259,14 +260,19 @@ def main(args: Optional[List[str]] = None, *, debug: bool = False) -> Dict[str, 
     if dropbox_token and is_atcoder and parsed.system:
         session.headers['Authorization'] = 'Bearer {}'.format(dropbox_token)
 
-    # set password to login from the environment variable
+    # set password / revel-session to login from the environment variable
     if parsed.subcommand == 'login-service':
         if parsed.password is not None:
             parser.error("don't use --password. use $PASSWORD")
+        if parsed.revel_session is not None:
+            parser.error("don't use --revel-session. use $REVEL_SESSION")
         if not parsed.check:
             parsed.password = os.environ.get('PASSWORD')
-            if not debug:
+            if 'PASSWORD' in os.environ and not debug:
                 del os.environ['PASSWORD']
+            parsed.revel_session = os.environ.get('REVEL_SESSION')
+            if 'REVEL_SESSION' in os.environ and not debug:
+                del os.environ['REVEL_SESSION']
 
     try:
         with utils.with_cookiejar(session, path=parsed.cookie) as session:
@@ -297,7 +303,7 @@ def main(args: Optional[List[str]] = None, *, debug: bool = False) -> Dict[str, 
             elif parsed.subcommand == 'login-service':
                 if service is None:
                     raise ValueError("unsupported URL: {}".format(repr(parsed.url)))
-                result = login_service.main(service, username=parsed.username, password=parsed.password, check_only=parsed.check, session=session)
+                result = login_service.main(service, username=parsed.username, password=parsed.password, revel_session=parsed.revel_session, check_only=parsed.check, session=session)
                 schema = login_service.schema
 
             elif parsed.subcommand == 'submit-code':


### PR DESCRIPTION
## Summary

AtCoder made two breaking changes in early 2025 that caused `oj`/`oj-api` to fail for all users:

1. **Memory limit units changed from MB/KB to MiB/KiB** — `_from_html` and `_from_table_row` crashed with `AssertionError` on every problem page.
2. **Cloudflare Turnstile CAPTCHA introduced** — automated username/password login via `oj-api login-service` is blocked.

This PR fixes both issues.

## Changes

### fix: support MiB/KiB memory limit units (`61ae95b`)

- Extend regex in `_from_html` to match `KB|MB|KiB|MiB`
- Add byte calculations for KiB (×1024) and MiB (×1048576) in `_from_table_row`
- Replace bare `assert` statements with `raise SampleParseError`/`raise ValueError` with descriptive messages

### fix: add `login_with_cookie` for AtCoder (`61ae95b`)

Add `AtCoderService.login_with_cookie(revel_session)` as a workaround for the Cloudflare CAPTCHA. The user logs in manually in their browser and passes the `REVEL_SESSION` cookie value directly.

```bash
REVEL_SESSION=xxxx oj-api login-service https://atcoder.jp/
```

The existing username/password `login()` method is kept as a fallback.

- `AtCoderService.login_with_cookie(revel_session, *, session)`: sets cookie, verifies via `is_logged_in()`
- `login_service.main()`: new `revel_session` parameter; uses cookie path when provided
- `oj-api login-service`: new `--revel-session` flag; also reads `$REVEL_SESSION` env var

### fix: defensive parsing across four methods (`54bd7b0`)

Replace chained `find()` calls and bare `assert` statements with explicit `None` checks and descriptive `ValueError` exceptions in:

- `_from_table_row`
- `_parse_available_languages`
- `_parse_score`
- `AtCoderContestDetailedData._from_response`

## Testing

Manually verified against live AtCoder pages (March 2026). The upstream test suite has no network tests for these paths.
